### PR TITLE
Attempt to fix console errors

### DIFF
--- a/src/components/layouts/Sidebar.tsx
+++ b/src/components/layouts/Sidebar.tsx
@@ -68,7 +68,6 @@ export default class Sidebar extends React.Component<{}> {
               {this.state.showBenchmarkSubmenu ? (
                 <Transition
                   component="div"
-                  measure={false}
                   enter={{
                     opacity: 1,
                     scale: 1
@@ -77,7 +76,8 @@ export default class Sidebar extends React.Component<{}> {
                     opacity: 0
                   }}
                 >
-                  <div>
+                  {/* Each transition child element should have a unique key */}
+                  <div key="compulsory_transition_key">
                     <Link to="/ping" style={{ textDecoration: 'none' }}>
                       <div>
                         <div className="sidebar-inner">

--- a/src/components/layouts/layouts.style.css
+++ b/src/components/layouts/layouts.style.css
@@ -147,7 +147,7 @@ header {
 
 .submenu-show-graph {
   padding: 2px;
-  position: absolute;
+  position: relative;
   margin: 3px 0px 3px 5px;
   font-size: 10px;
   right: 1%;


### PR DESCRIPTION
Signed-off-by: Aquib Baig <aquibbaig97@gmail.com>

- Added a key to children transition elements of react-motion-ui, we have one child here
- Position of the show button should be relative, not absolute
- Remove measure field from the Transition, as it is a non-boolean measurable component ("div")